### PR TITLE
Fixed/added generation of the ASTRA_GRAPHQL_ENDPOINT in the .env file

### DIFF
--- a/src/astra-setup.js
+++ b/src/astra-setup.js
@@ -1,5 +1,5 @@
-
 #!/usr/bin/env node
+
 const astraCollections = require('@astrajs/collections');
 const astraRest = require('@astrajs/rest');
 const chalk = require('chalk');
@@ -145,6 +145,7 @@ class astraClient {
 		setEnv("ASTRA_DB_ID", this.db.value );
 		setEnv("ASTRA_DB_REGION", this.db.region);
 		setEnv("ASTRA_DB_KEYSPACE", astra_keyspace );
+		setEnv("ASTRA_GRAPHQL_ENDPOINT", "https://" + this.db.value + "-" + this.db.region + ".apps.astra.datastax.com/api/graphql/" + astra_keyspace)
 
 		// Check for the keyspace
 		console.log(chalk.green('Checking for keyspace ' + astra_keyspace));
@@ -407,7 +408,7 @@ async function start() {
 			setEnv("ASTRA_DB_ID", client.db.value );
 			setEnv("ASTRA_DB_REGION", client.db.region);
 			setEnv("ASTRA_DB_KEYSPACE", argv_keyspace );
-			setEnv("ASTRA_GRAPHQL_ENDPOINT", "https://" + client.db.value + "-" + client.db.region + ".apps.astra.datastax.com/api/graphql/" + client.db.keyspace)
+			setEnv("ASTRA_GRAPHQL_ENDPOINT", "https://" + client.db.value + "-" + client.db.region + ".apps.astra.datastax.com/api/graphql/" + argv_keyspace)
 			console.log(chalk.yellow("Setting up secure bundle"))
 			await client.getBundle(client.db.value)
 		}
@@ -451,6 +452,7 @@ async function start() {
 			setEnv("ASTRA_DB_ID", client.db.value );
 			setEnv("ASTRA_DB_REGION", client.db.region);
 			setEnv("ASTRA_DB_KEYSPACE", answers.keyspace );
+			setEnv("ASTRA_GRAPHQL_ENDPOINT", "https://" + client.db.value + "-" + client.db.region + ".apps.astra.datastax.com/api/graphql/" + answers.keyspace)
 			break;
 		case 2:
 			await client.findDatabases();
@@ -512,6 +514,7 @@ async function start() {
 				await client.findDatabasebyName(client.db.title, true);
 			}
 			setEnv("ASTRA_DB_KEYSPACE", keyspace.keyspace );
+			setEnv("ASTRA_GRAPHQL_ENDPOINT", "https://" + client.db.value + "-" + client.db.region + ".apps.astra.datastax.com/api/graphql/" + keyspace.keyspace)
 
 			
 			break;


### PR DESCRIPTION
(1) The GraphQL endpoint, in the path with db and keyspace provided by
command line, was mistakenly constructed using all keyspaces found in the
database as a comma-separated list in the URL itself. Now the one desired
keyspace is used to generate the URL.
(2) in the other three paths (no arguments on the command line:
default/create/existing interactive menu) the GraphQL endpoint was not
appearing in the resulting .env. Now that line is generated, so that all ways
to use this utility result in a .env file with the same structure.

The line I changed for the path with command-line arguments provided replaces "client.db.keyspace" with "argv_keyspace". The first is actually a list (of all keyspaces in the db). The second, strictly speaking, is the name of the keyspace *desired* by the user - but at this point in the script flow it is certain that the keyspace has been created.
(if this assumption seems too sloppy, it could be the case to filter the list to make sure the desired keyspace is there: if for some reason it is not found, issue an error, etc etc.).
Similar (mild) assumption underlie the other analogous lines inserted, which take care of creating the GraphQL env variable in the other paths.
